### PR TITLE
Added request which sends form data to google form

### DIFF
--- a/src/components/GetInvolved/Confirm.js
+++ b/src/components/GetInvolved/Confirm.js
@@ -3,6 +3,23 @@ import { List, ListItem, ListItemText, Button } from '@material-ui/core';
 
 const Confirm = (props) => {
   const { firstName, lastName, email, hearAboutUs } = props.inputValues
+  
+  // put the form body in x-www-form-urlencoded format
+  const formBody = "entry.2077980149=" + firstName + "&entry.1632250722=" + lastName + "&entry.30371003=" + email + "&entry.2040370053=" + hearAboutUs
+
+  // Send form data to google forms once user confirms
+  async function handleConfirm() {
+    const url = `https://docs.google.com/forms/u/0/d/e/1FAIpQLSf4L4KHuASRhHKreTjd7mUj8f2CTAM7B8eQWQ4zuLxDwUKwTQ/formResponse`
+    const response = await fetch(url, {
+      method: 'POST',
+      mode: 'no-cors',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+      },
+      body: formBody
+    })
+    props.nextStep()
+  }
 
   return (
     <>
@@ -30,7 +47,7 @@ const Confirm = (props) => {
       <Button
         color="primary"
         variant="contained"
-        onClick={() => props.nextStep()}
+        onClick={() => handleConfirm()}
       >Confirm</Button>
     </>
   )


### PR DESCRIPTION
I created a google form with with the fields and got the end point from the inspect page. Now when user submits a get involved form it gets added to the google form. The url can easily be switched to client's google form endpoint. 

[resource used](https://theconfuzedsourcecode.wordpress.com/2019/11/11/you-may-restfully-submit-to-your-google-forms/)